### PR TITLE
fix: enable DefaultParser in default config

### DIFF
--- a/tika-config.xml
+++ b/tika-config.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <properties>
   <parsers>
+    <parser class="org.apache.tika.parser.DefaultParser">
+    </parser>
     <parser class="org.apache.tika.parser.ocr.TesseractOCRParser">
       <params>
         <param name="timeout" type="int">300</param>


### PR DESCRIPTION
If the DefaultParser is not included in the config file, we lose out on
its auto-discovery feature (i.e. Tika won't pick the best parser for the
uploaded file, and just depend on the hardcoded parsers that were
defined).

This commit re-enables the DefaultParser so that Tika can use the right
parsers as it sees fit, while still keeping the param overrides for the
TesseractOCRParser.